### PR TITLE
Update LoliConfig.kt

### DIFF
--- a/src/main/kotlin/LoliConfig.kt
+++ b/src/main/kotlin/LoliConfig.kt
@@ -195,7 +195,7 @@ object LoliConfig : ReadOnlyPluginConfig("config") {
     fun resolveKeyword(message: MessageChain, at: Boolean): Keyword? {
         val key = message.filterIsInstance<PlainText>().joinToString { it.content }.trimStart().trimEnd()
         val keyword = keywords[key] ?: return null
-        return if (keyword.at && !at) null else keyword
+        return if (keyword.at && !at) keyword else null
     }
 
     @OptIn(ConsoleExperimentalApi::class)


### PR DESCRIPTION
修复了关键词正确时无法响应指令的问题
if语句的前后貌似写反了，导致关键词匹配成功的时候会返回null（奇怪，之前怎么有人能用成功的）
修改顺序之后功能恢复正常